### PR TITLE
fix(zpp_throwing.h/catch_exception_object): remove unneeded unnamed parameter packs

### DIFF
--- a/zpp_throwing.h
+++ b/zpp_throwing.h
@@ -1233,7 +1233,6 @@ private:
      */
     template <typename Clause,
               typename... Clauses,
-              typename...,
               typename CatchType = detail::catch_value_type_t<Clause>,
               bool IsThrowing = requires
     {
@@ -1420,7 +1419,6 @@ private:
      */
     template <typename Clause,
               typename... Clauses,
-              typename...,
               typename CatchType = detail::catch_value_type_t<Clause>,
               bool IsThrowing = requires
     {


### PR DESCRIPTION
Violates C++ Standard Rules and improves MSVC compatibility which correctly implements the standard.

https://timsong-cpp.github.io/cppwp/temp.param#14