### PR TITLE
fix(zpp_throwing.h/exception_holder/dynamic_object): do not use trailing return specifier

### DIFF
--- a/zpp_throwing.h
+++ b/zpp_throwing.h
@@ -775,8 +775,7 @@ struct exit_condition
             {
             }
 
-            auto dynamic_object() noexcept
-                -> struct dynamic_object override
+            struct dynamic_object dynamic_object() noexcept override
             {
                 // Return the type id of the exception object and its
                 // address.


### PR DESCRIPTION
MSVC seems to error out with the same